### PR TITLE
Fixes for some defines

### DIFF
--- a/src/defaults/instruction_format.sv
+++ b/src/defaults/instruction_format.sv
@@ -114,21 +114,21 @@
  * Equivalent to having (imm_20_bits << 1). So we have imm[20:1].
  */
 
-`define B_IMM_SIZE	20
+`define J_IMM_SIZE	20
 
 /* Bit 20. */
-`define B_IMM_MSB		31
+`define J_IMM_MSB		31
 
 /* imm[19:12]. */
-`define B_IMM_LOW_BITS_MSB	19
-`define B_IMM_LOW_BITS_LSB	12
+`define J_IMM_LOW_BITS_MSB	19
+`define J_IMM_LOW_BITS_LSB	12
 
 /* Bit 11. */
-`define B_IMM_MID_BIT		20
+`define J_IMM_MID_BIT		20
 
 /* imm[10:1]. */
-`define B_IMM_MID_BITS_MSB	30
-`define B_IMM_MID_BITS_LSB	21
+`define J_IMM_MID_BITS_MSB	30
+`define J_IMM_MID_BITS_LSB	21
 
 
 /* ------------------------------------------------------------------------- */

--- a/src/defaults/instructions_and_masks.sv
+++ b/src/defaults/instructions_and_masks.sv
@@ -60,12 +60,6 @@
 `define INSTR_MASK_BGEU	`BRANCH_INSTRS_MASK
 
 
-/* Don't expose temporary macros used for readability / generation outside. */
-
-`undef BRANCH_INSTR_CREATE
-`undef BRANCH_INSTRS_MASK
-
-
 /* ------------------------------------------------------------------------- */
 
 
@@ -91,12 +85,6 @@
 `define INSTR_MASK_LHU	`LOAD_INSTRS_MASK
 
 
-/* Don't expose temporary macros used for readability / generation outside. */
-
-`undef LOAD_INSTR_CREATE
-`undef LOAD_INSTRS_MASK
-
-
 /* ------------------------------------------------------------------------- */
 
 
@@ -114,12 +102,6 @@
 
 `define INSTR_SW	`STORE_INSTR_CREATE(3'b010)
 `define INSTR_MASK_SW	`STORE_INSTRS_MASK
-
-
-/* Don't expose temporary macros used for readability / generation outside. */
-
-`undef STORE_INSTR_CREATE
-`undef STORE_INSTRS_MASK
 
 
 /* ------------------------------------------------------------------------- */
@@ -168,14 +150,6 @@
 `define INSTR_MASK_SRAI	`IMM_SHIFT_INSTRS_MASK
 
 
-/* Don't expose temporary macros used for readability / generation outside. */
-
-`undef IMM_AL_INSTR_CREATE
-`undef IMM_AL_INSTRS_MASK
-`undef IMM_SHIFT_INSTR_CREATE
-`undef IMM_SHIFT_INSTRS_MASK
-
-
 /* ------------------------------------------------------------------------- */
 
 
@@ -217,12 +191,6 @@
 `define INSTR_MASK_AND	`ALU_INSTRS_MASK
 
 
-/* Don't expose temporary macros used for readability / generation outside. */
-
-`undef ALU_INSTR_CREATE
-`undef ALU_INSTRS_MASK
-
-
 /* ------------------------------------------------------------------------- */
 
 
@@ -244,12 +212,6 @@
 
 `define INSTR_EBREAK		`ENV_INSTR_CREATE(1'b1)
 `define INSTR_MASK_EBREAK	`ENV_INSTRS_MASK
-
-
-/* Don't expose temporary macros used for readability / generation outside. */
-
-`undef ENV_INSTR_CREATE
-`undef ENV_INSTRS_MASK
 
 
 /* ------------------------------------------------------------------------- */


### PR DESCRIPTION
Encountered errors in Quartus while checking up if else for decoder, so fixed them up.

- instruction_format: J type macros were erroneously named B type (forgot to change after Ctrl+C lol).

- instructions_and_masks: undef is erroneous, files won't be necessarily preprocessed in order. Thus remove those lines.

