### PR TITLE
Add .editorconfig for consistent styling across editors

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: MIT
+
+# Topmost file.
+root = true
+
+
+# -----------------------------------------------------------------------------
+
+
+# For all files.
+
+[*]
+charset = utf-8
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = tab
+indent_size = 8
+tab_width = 8
+
+
+# -----------------------------------------------------------------------------
+
+
+# Override for Python.
+
+[*.py]
+indent_style = spaces
+indent_size = 4
+
+
+# -----------------------------------------------------------------------------
+
+
+# End of file.


### PR DESCRIPTION
Check out https://editorconfig.org.

Configure for tab indentation, 8-char wide (inspired by kernel codestyle).

We can override rules too. For example, Python essentially enforces 4 spaces, so have override for it. We currently don't use Python, but there is a chance to use later.